### PR TITLE
Fixed readme link to renamed plugin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ You can validate individual asset names by defining a prefix and / or a suffix b
 
 But you can also implement more complicated validation rules, like making sure all assets inside a folder have a keyword in their name.
 
-Check the [documentation](https://theemidee.github.io/UE4NamingConventionValidation/) for all the informations.
+Check the [documentation](https://theemidee.github.io/UENamingConventionValidation/) for all the informations.

--- a/Source/NamingConventionValidation/Private/NamingConventionValidationSettings.cpp
+++ b/Source/NamingConventionValidation/Private/NamingConventionValidationSettings.cpp
@@ -1,4 +1,5 @@
 #include "NamingConventionValidation/Public/NamingConventionValidationSettings.h"
+#include "NamingConventionValidationLog.h"
 
 UNamingConventionValidationSettings::UNamingConventionValidationSettings()
 {
@@ -45,3 +46,45 @@ bool UNamingConventionValidationSettings::IsPathExcludedFromValidation( const FS
 
     return false;
 }
+
+void UNamingConventionValidationSettings::PostProcessSettings()
+{
+    for ( auto & class_description : ClassDescriptions )
+    {
+        class_description.Class = class_description.ClassPath.LoadSynchronous();
+
+        UE_CLOG( class_description.Class == nullptr, LogNamingConventionValidation, Warning, TEXT( "Impossible to get a valid UClass for the classpath %s" ), *class_description.ClassPath.ToString() );
+    }
+
+    ClassDescriptions.Sort();
+
+    for ( auto & class_path : ExcludedClassPaths )
+    {
+        auto * excluded_class = class_path.LoadSynchronous();
+        UE_CLOG( excluded_class == nullptr, LogNamingConventionValidation, Warning, TEXT( "Impossible to get a valid UClass for the excluded classpath %s" ), *class_path.ToString() );
+
+        if ( excluded_class != nullptr )
+        {
+            ExcludedClasses.Add( excluded_class );
+        }
+    }
+
+    static const FDirectoryPath
+        EngineDirectoryPath( { TEXT( "/Engine/" ) } );
+
+    // Cannot use AddUnique since FDirectoryPath does not have operator==
+    if ( !ExcludedDirectories.ContainsByPredicate( []( const auto & item ) {
+             return item.Path == EngineDirectoryPath.Path;
+         } ) )
+    {
+        ExcludedDirectories.Add( EngineDirectoryPath );
+    }
+}
+
+#if WITH_EDITOR
+void UNamingConventionValidationSettings::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
+{
+    Super::PostEditChangeProperty(PropertyChangedEvent);
+    PostProcessSettings();
+}
+#endif

--- a/Source/NamingConventionValidation/Public/NamingConventionValidationSettings.h
+++ b/Source/NamingConventionValidation/Public/NamingConventionValidationSettings.h
@@ -18,10 +18,10 @@ struct FNamingConventionValidationClassDescription
 
     bool operator<( const FNamingConventionValidationClassDescription & other ) const
     {
-        return Priority > other.Priority;
+        return Priority > other.Priority || ((Class && other.Class) ? (Class->GetName() < other.Class->GetName()) : false);
     }
 
-    UPROPERTY( config, EditAnywhere )
+    UPROPERTY( config, EditAnywhere, meta = ( AllowAbstract = true ) )
     TSoftClassPtr< UObject > ClassPath;
 
     UPROPERTY( transient )
@@ -37,7 +37,7 @@ struct FNamingConventionValidationClassDescription
     int Priority;
 };
 
-UCLASS( config = Editor )
+UCLASS( config = Editor, DefaultConfig )
 class NAMINGCONVENTIONVALIDATION_API UNamingConventionValidationSettings final : public UDeveloperSettings
 {
     GENERATED_BODY()
@@ -81,4 +81,10 @@ public:
 
     UPROPERTY( config, EditAnywhere )
     FString BlueprintsPrefix;
+
+    void PostProcessSettings();
+
+#if WITH_EDITOR
+    virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+#endif
 };

--- a/_clang-format
+++ b/_clang-format
@@ -1,0 +1,5 @@
+---
+DisableFormat: 'true'
+SortIncludes: 'false'
+
+...


### PR DESCRIPTION
I noticed the link from the readme file was outdated and did not point at the renamed docs page.