### PR TITLE
editor_validator_fixes

### DIFF
--- a/Source/NamingConventionValidation/Private/EditorNamingValidatorSubsystem.cpp
+++ b/Source/NamingConventionValidation/Private/EditorNamingValidatorSubsystem.cpp
@@ -451,7 +451,7 @@ ENamingConventionValidationResult UEditorNamingValidatorSubsystem::DoesAssetMatc
         {
             const auto result = validator_pair.Value->ValidateAssetNaming( error_message, asset_class, asset_data );
 
-            if ( result != ENamingConventionValidationResult::Unknown )
+            if ( result != ENamingConventionValidationResult::Valid )
             {
                 return result;
             }

--- a/Source/NamingConventionValidation/Public/EditorNamingValidatorBase.h
+++ b/Source/NamingConventionValidation/Public/EditorNamingValidatorBase.h
@@ -7,7 +7,7 @@
 
 #include "EditorNamingValidatorBase.generated.h"
 
-UCLASS()
+UCLASS( Abstract, Blueprintable, meta = (ShowWorldContextPin) )
 class NAMINGCONVENTIONVALIDATION_API UEditorNamingValidatorBase : public UObject
 {
     GENERATED_BODY()


### PR DESCRIPTION
- Made UEditorNamingValidatorBase blueprintable
- Stop validating with editor validators when one returns an invalid result
